### PR TITLE
Update manager_action_damage.lua to modify rather than replace the original ActionDamage

### DIFF
--- a/extension.xml
+++ b/extension.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root version="3.3.15.1" release="1">
   <properties>
-    <name>Feature: Extended automation and overlays test</name>
+    <name>Feature: Extended automation and overlays</name>
     <version>3.3.15.1</version>
     <author>mr900rr (FFOS), darrenan (keen), phixation (bypass), tahl_liadon (some icons), bmos (TQ and more), DCrumb (max tag), RabidPaladin (better NPC parsing and resisthalved) and Kelrugem (rest)</author>
     <description>Deekin ist super! (Will ever someone read that strange description?)</description>
@@ -38,9 +38,9 @@
 	
     <!-- High-level scripts -->
 	<script name="ActionsManagerKel" file="scripts/manager_actions.lua" />
-    <script name="CombatManagerKel" file="scripts/manager_combat.lua" />
-    <script name="ActionDamageKel" file="scripts/manager_action_damage.lua" />
-    <script name="OptionsInit" file="scripts/data_options_init.lua" />
+	<script name="CombatManagerKel" file="scripts/manager_combat.lua" />
+	<script name="ActionDamageKel" file="scripts/manager_action_damage.lua" />
+	<script name="OptionsInit" file="scripts/data_options_init.lua" />
 	<script name="DataCommon2" file="scripts/data_common2.lua" />
 	<script name="GameSystem2" file="scripts/manager_gamesystem2.lua" />
 	<script name="CombatManager2" file="scripts/manager_combat2.lua" />

--- a/extension.xml
+++ b/extension.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root version="3.3.15.1" release="1">
   <properties>
-    <name>Feature: Extended automation and overlays</name>
+    <name>Feature: Extended automation and overlays test</name>
     <version>3.3.15.1</version>
     <author>mr900rr (FFOS), darrenan (keen), phixation (bypass), tahl_liadon (some icons), bmos (TQ and more), DCrumb (max tag), RabidPaladin (better NPC parsing and resisthalved) and Kelrugem (rest)</author>
     <description>Deekin ist super! (Will ever someone read that strange description?)</description>
@@ -39,6 +39,7 @@
     <!-- High-level scripts -->
 	<script name="ActionsManagerKel" file="scripts/manager_actions.lua" />
     <script name="CombatManagerKel" file="scripts/manager_combat.lua" />
+    <script name="ActionDamageKel" file="scripts/manager_action_damage.lua" />
     <script name="OptionsInit" file="scripts/data_options_init.lua" />
 	<script name="DataCommon2" file="scripts/data_common2.lua" />
 	<script name="GameSystem2" file="scripts/manager_gamesystem2.lua" />
@@ -47,7 +48,6 @@
 	<script name="ActorManager35E" file="scripts/manager_actor_35E.lua" />
 	<script name="TokenManager3" file="scripts/manager_token2.lua" />
 	<script name="ActionAttack" file="scripts/manager_action_attack.lua" />
-    <script name="ActionDamage" file="scripts/manager_action_damage.lua" />
 	<script name="ActionHeal" file="scripts/manager_action_heal.lua" />
 	<script name="EffectManager35E" file="scripts/manager_effect_35E.lua" />
 	<script name="SpellManager" file="scripts/manager_spell.lua" />

--- a/scripts/manager_action_damage.lua
+++ b/scripts/manager_action_damage.lua
@@ -35,7 +35,6 @@ function onInit()
 end
 
 function handleApplyDamage(msgOOB)
-	Debug.chat("Kel's handleApplyDamage")
 	local rSource = ActorManager.resolveActor(msgOOB.sSourceNode);
 	local rTarget = ActorManager.resolveActor(msgOOB.sTargetNode);
 	local bImmune = {};
@@ -231,7 +230,6 @@ end
 
 -- KEL add attackfilter etc
 function notifyApplyDamage(rSource, rTarget, bSecret, sRollType, sDesc, nTotal, sAttackFilter, tag)
-	Debug.chat("Kel's notifyApplyDamage")
 	if not rTarget then
 		return;
 	end
@@ -258,31 +256,6 @@ function notifyApplyDamage(rSource, rTarget, bSecret, sRollType, sDesc, nTotal, 
 
 	Comm.deliverOOBMessage(msgOOB, "");
 end
-
--- function modDamage(rSource, rTarget, rRoll)
--- 	Debug.chat("Kel's  modDamage")
--- 	ActionDamage.setupModRoll(rRoll, rSource, rTarget);
-
--- 	if rSource then
--- 		ActionDamage.applyAbilityEffectsToModRoll(rRoll, rSource, rTarget);
--- 	end
-
--- 	if rRoll.bCritical then
--- 		ActionDamage.applyCriticalToModRoll(rRoll, rSource, rTarget);
--- 	end
-
--- 	if rSource then
--- 		ActionDamage.applyDmgEffectsToModRoll(rRoll, rSource, rTarget);
--- 		ActionDamage.applyConditionsToModRoll(rRoll, rSource, rTarget);
--- 		ActionDamage.applyEffectModNotificationToModRoll(rRoll);
-
--- 		ActionDamage.applyDmgTypeEffectsToModRoll(rRoll, rSource, rTarget);
--- 	end
-
--- 	ActionDamage.applyModifierKeysToModRoll(rRoll, rSource, rTarget);
-
--- 	ActionDamage.finalizeModRoll(rRoll);
--- end
 
 -- KEL TDMG
 function notifyTDMGRollOnClient(msgOOB)
@@ -362,7 +335,6 @@ end
 -- END
 
 function onDamage(rSource, rTarget, rRoll)
-	Debug.chat("Kel's onDamage")
 	local rMessage = ActionsManager.createActionMessage(rSource, rRoll);
 	rMessage.text = string.gsub(rMessage.text, " %[MOD:[^]]*%]", "");
 	rMessage.text = string.gsub(rMessage.text, " %[MULT:[^]]*%]", "");
@@ -400,7 +372,6 @@ end
 --
 
 function applyDmgEffectsToModRoll(rRoll, rSource, rTarget)
-	Debug.chat("Kel's  applyDmgEffectsToModRoll")
 	local tEffects, nEffectCount;
 	if rRoll.sType == "spdamage" then
 		tEffects, nEffectCount = EffectManager35E.getEffectsBonusByType(rSource, "DMGS", true, rRoll.tAttackFilter, rTarget, false, rRoll.tags);
@@ -489,7 +460,6 @@ function applyDmgEffectsToModRoll(rRoll, rSource, rTarget)
 end
 
 function applyConditionsToModRoll(rRoll, rSource, rTarget)
-	Debug.chat("Kel's applyConditionsToModRoll")
 	if rRoll.sType ~= "spdamage" then
 		if EffectManager35E.hasEffectCondition(rSource, "Sickened", rRoll.tags) then
 			rRoll.nMod = rRoll.nMod - 2;
@@ -505,7 +475,6 @@ function applyConditionsToModRoll(rRoll, rSource, rTarget)
 end
 
 function applyDmgTypeEffectsToModRoll(rRoll, rSource, rTarget)
-	Debug.chat("Kel's applyDmgTypeEffectsToModRoll")
 	local tAddDmgTypes = {};
 	local tDmgTypeEffects;
 	if rRoll.sType == "spdamage" then
@@ -545,7 +514,6 @@ end
 
 -- KEL bImmune, bFortif
 function getDamageAdjust(rSource, rTarget, nDamage, rDamageOutput, bImmune, bFortif, tags)
-	Debug.chat("Kel's getDamageAdjust")
 	-- SETUP
 	local nDamageAdjust = 0;
 	local nNonlethal = 0;
@@ -1232,7 +1200,6 @@ end
 
 -- KEL bImmune, bFortif, tags
 function applyDamage(rSource, rTarget, bSecret, sRollType, sDamage, nTotal, bImmune, bFortif, tags)
-	Debug.chat("Kel's applyDamage")
 	local nTotalHP = 0;
 	local nTempHP = 0;
 	local nNonLethal = 0;

--- a/scripts/manager_action_damage.lua
+++ b/scripts/manager_action_damage.lua
@@ -314,294 +314,27 @@ function modStabilization(rSource, rTarget, rRoll)
 end
 
 function modDamage(rSource, rTarget, rRoll)
-	decodeDamageTypes(rRoll);
-	-- KEL here problem of the ADV DISADV thing?
-	CombatManager2.addRightClickDiceToClauses(rRoll);
-	-- END
-	-- Set up
-	local aAddDesc = {};
-	local aAddDice = {};
-	local nAddMod = 0;
-	local bEffects = false;
-	local aEffectDice = {};
-	local nEffectMod = 0;
-	local bPFMode = DataCommon.isPFRPG();
-	
-	-- Build attack type filter
-	local aAttackFilter = {};
-	if rRoll.range == "R" then
-		table.insert(aAttackFilter, "ranged");
-	elseif rRoll.range == "M" then
-		table.insert(aAttackFilter, "melee");
-	end
-	
-	-- Handle ability effects
+	ActionDamage.setupModRoll(rRoll, rSource, rTarget);
+
 	if rSource then
-		-- Apply ability modifiers
-		for kClause,vClause in ipairs(rRoll.clauses) do
-			-- Get original stat modifier
-			local nStatMod = ActorManager35E.getAbilityBonus(rSource, vClause.stat);
-			-- Get any stat effects bonus
-			-- KEL Add tags
-			local nBonusStat, nBonusEffects = ActorManager35E.getAbilityEffectsBonus(rSource, vClause.stat, rRoll.tags);
-			-- END
-			if nBonusEffects > 0 then
-				bEffects = true;
-				
-				-- Calc total stat mod
-				local nTotalStatMod = nStatMod + nBonusStat;
-				
-				-- Handle maximum stat mod setting
-				-- WORKAROUND: If max limited, then assume no penalty allowed (i.e. bows)
-				local nStatModMax = vClause.statmax or 0;
-				if nStatModMax > 0 then
-					nStatMod = math.max(math.min(nStatMod, nStatModMax), 0);
-					nTotalStatMod = math.max(math.min(nTotalStatMod, nStatModMax), 0);
-				end
-				-- KEL Here for ADV etc.?
-				-- Handle multipliers correctly
-				-- NOTE: Negative values are not multiplied, but positive values are.
-				local nMult = vClause.statmult or 1;
-				local nMultOrigStatMod, nMultNewStatMod;
-				if nStatMod <= 0 then
-					nMultOrigStatMod = nStatMod;
-				else
-					nMultOrigStatMod = math.floor(nStatMod * nMult);
-				end
-				if nTotalStatMod <= 0 then
-					nMultNewStatMod = nTotalStatMod;
-				else
-					nMultNewStatMod = math.floor(nTotalStatMod * nMult);
-				end
-				
-				-- Calculate bonus difference
-				local nMultDiffStatMod = nMultNewStatMod - nMultOrigStatMod;
-				if bCritical then
-					local nCritMult = vClause.mult or 2;
-					nMultDiffStatMod = nMultDiffStatMod * nCritMult;
-				end
-				
-				-- Apply bonus difference
-				nEffectMod = nEffectMod + nMultDiffStatMod;
-				vClause.modifier = vClause.modifier + nMultDiffStatMod;
-				rRoll.nMod = rRoll.nMod + nMultDiffStatMod;
-			end
-		end
+		ActionDamage.applyAbilityEffectsToModRoll(rRoll, rSource, rTarget);
 	end
 
-	-- Handle critical
-	local bCritical = ModifierStack.getModifierKey("DMG_CRIT") or Input.isShiftPressed();
-	if ActionAttack.isCrit(rSource, rTarget) then
-		bCritical = true;
+	if rRoll.bCritical then
+		ActionDamage.applyCriticalToModRoll(rRoll, rSource, rTarget);
 	end
-	if bCritical then
-		table.insert(aAddDesc, "[CRITICAL]");
 
-		local nDieIndex = 1;
-		local aNewClauses = {};
-		for _,vClause in ipairs(rRoll.clauses) do
-			nDieIndex = nDieIndex + #(vClause.dice);
-			
-			table.insert(aNewClauses, vClause);
-			
-			local nMult = vClause.mult or 2;
-			if nMult > 1 then
-				local rNewClause = UtilityManager.copyDeep(vClause);
-				rNewClause.dice = {};
-				rNewClause.modifier = 0;
-				if rNewClause.dmgtype == "" then
-					rNewClause.dmgtype = "critical";
-				else
-					rNewClause.dmgtype = rNewClause.dmgtype .. ",critical";
-				end
-				
-				local nDice = #(vClause.dice);
-				local nMod = vClause.modifier or 0;
-				
-				for i = 2, nMult do
-					for j = 1, nDice do
-						if vClause.dice[j]:sub(1,1) == "-" then
-							table.insert(rRoll.aDice, nDieIndex, "-g" .. vClause.dice[j]:sub(3));
-						else
-							table.insert(rRoll.aDice, nDieIndex, "g" .. vClause.dice[j]:sub(2));
-						end
-						nDieIndex = nDieIndex + 1;
-						table.insert(rNewClause.dice, vClause.dice[j]);
-					end
-					rRoll.nMod = rRoll.nMod + nMod;
-					rNewClause.modifier = rNewClause.modifier + nMod;
-				end
-				
-				table.insert(aNewClauses, rNewClause);
-			end
-		end
-		rRoll.clauses = aNewClauses;
-	end
-	
-	-- Handle general damage effects
 	if rSource then
-		local aEffects, nEffectCount;
-		-- KEL add tags
-		if rRoll.sType == "spdamage" then
-			aEffects, nEffectCount = EffectManager35E.getEffectsBonusByType(rSource, "DMGS", true, aAttackFilter, rTarget, false, rRoll.tags);
-		else
-			aEffects, nEffectCount = EffectManager35E.getEffectsBonusByType(rSource, "DMG", true, aAttackFilter, rTarget, false, rRoll.tags);
-		end
-		-- END
-		if nEffectCount > 0 then
-			-- Use the first damage clause to determine damage type and crit multiplier for effect damage
-			local nEffectCritMult = 2;
-			local sEffectBaseType = "";
-			if #(rRoll.clauses) > 0 then
-				nEffectCritMult = rRoll.clauses[1].mult or 2;
-				sEffectBaseType = rRoll.clauses[1].dmgtype or "";
-			end
+		ActionDamage.applyDmgEffectsToModRoll(rRoll, rSource, rTarget);
+		ActionDamage.applyConditionsToModRoll(rRoll, rSource, rTarget);
+		ActionDamage.applyEffectModNotificationToModRoll(rRoll);
 
-			-- For each effect, add a damage clause
-			for _,v in pairs(aEffects) do
-				-- Process effect damage types
-				local bEffectPrecision = false;
-				local bEffectCritical = false;
-				local aEffectDmgType = {};
-				local aEffectSpecialDmgType = {};
-				for _,sWord in ipairs(v.remainder) do
-					if StringManager.contains(DataCommon.specialdmgtypes, sWord) then
-						table.insert(aEffectSpecialDmgType, sWord);
-						if sWord == "critical" then
-							bEffectCritical = true;
-						elseif sWord == "precision" then
-							bEffectPrecision = true;
-						end
-					elseif StringManager.contains(DataCommon.dmgtypes, sWord) then
-						table.insert(aEffectDmgType, sWord);
-					end
-				end
-				
-				if not bEffectCritical or bCritical then
-					bEffects = true;
-					
-					local rClause = {};
-					
-					-- Add effect dice
-					rClause.dice = {};
-					for _,vDie in ipairs(v.dice) do
-						table.insert(aEffectDice, vDie);
-						table.insert(rClause.dice, vDie);
-						if vDie:sub(1,1) == "-" then
-							table.insert(rRoll.aDice, "-p" .. vDie:sub(3));
-						else
-							table.insert(rRoll.aDice, "p" .. vDie:sub(2));
-						end
-					end
-
-					if #aEffectDmgType == 0 then
-						table.insert(aEffectDmgType, sEffectBaseType);
-					end
-					for _,vSpecialDmgType in ipairs(aEffectSpecialDmgType) do
-						table.insert(aEffectDmgType, vSpecialDmgType);
-					end
-					rClause.dmgtype = table.concat(aEffectDmgType, ",");
-
-					local nCurrentMod = v.mod;
-					nEffectMod = nEffectMod + nCurrentMod;
-					rClause.modifier = nCurrentMod;
-					rRoll.nMod = rRoll.nMod + nCurrentMod;
-
-					table.insert(rRoll.clauses, rClause);
-					
-					-- Add critical effect modifier
-					local nCurrentMod;
-					if bCritical and not bEffectPrecision and not bEffectCritical and nEffectCritMult > 1 then
-						local rClauseCritical = {};
-						nCurrentMod = (v.mod * (nEffectCritMult - 1));
-						rClauseCritical.modifier = nCurrentMod;
-						if rClause.dmgtype == "" then
-							rClauseCritical.dmgtype = "critical";
-						else
-							rClauseCritical.dmgtype = rClause.dmgtype .. ",critical";
-						end
-						table.insert(rRoll.clauses, rClauseCritical);
-
-						nEffectMod = nEffectMod + nCurrentMod;
-						rRoll.nMod = rRoll.nMod + nCurrentMod;
-					end
-					
-				end
-			end
-		end
-		
-		-- Apply damage type modifiers
-		-- KEL Making DMG(S)TYPE targetable. Also adding tags
-		if rRoll.sType == "spdamage" then
-			aEffects = EffectManager35E.getEffectsByType(rSource, "DMGSTYPE", {}, rTarget, false, rRoll.tags);
-		else
-			aEffects = EffectManager35E.getEffectsByType(rSource, "DMGTYPE", {}, rTarget, false, rRoll.tags);
-		end
-		-- END
-		local aAddTypes = {};
-		for _,v in ipairs(aEffects) do
-			for _,v2 in ipairs(v.remainder) do
-				if StringManager.contains(DataCommon.dmgtypes, v2) then
-					table.insert(aAddTypes, v2);
-				end
-			end
-		end
-		if #aAddTypes > 0 then
-			for _,vClause in ipairs(rRoll.clauses) do
-				local aSplitTypes = StringManager.split(vClause.dmgtype, ",", true);
-				for _,v2 in ipairs(aAddTypes) do
-					if not StringManager.contains(aSplitTypes, v2) then
-						if vClause.dmgtype ~= "" then
-							vClause.dmgtype = vClause.dmgtype .. "," .. v2;
-						else
-							vClause.dmgtype = v2;
-						end
-					end
-				end
-			end
-		end
-		
-		-- Apply condition modifiers
-		-- KEL adding tags
-		if rRoll.sType ~= "spdamage" then
-			if EffectManager35E.hasEffectCondition(rSource, "Sickened", rRoll.tags) then
-				rRoll.nMod = rRoll.nMod - 2;
-				nEffectMod = nEffectMod - 2;
-				bEffects = true;
-			end
-			if EffectManager35E.hasEffect(rSource, "Incorporeal", nil, false, false, rRoll.tags) and rRoll.range == "M" and not string.match(string.lower(rRoll.sDesc), "incorporeal touch") then
-				bEffects = true;
-				table.insert(aAddDesc, "[INCORPOREAL]");
-			end
-		end
-		-- END
-	end
-	
-	-- Handle half damage
-	local bHalf = ModifierStack.getModifierKey("DMG_HALF");
-	if bHalf then
-		table.insert(aAddDesc, "[HALF]");
-	end
-	
-	-- Add note about effects
-	if bEffects then
-		local sEffects = "";
-		local sMod = StringManager.convertDiceToString(aEffectDice, nEffectMod, true);
-		if sMod ~= "" then
-			sEffects = "[" .. Interface.getString("effects_tag") .. " " .. sMod .. "]";
-		else
-			sEffects = "[" .. Interface.getString("effects_tag") .. "]";
-		end
-		table.insert(aAddDesc, sEffects);
-	end
-	
-	-- Add notes to roll description
-	if #aAddDesc > 0 then
-		rRoll.sDesc = rRoll.sDesc .. " " .. table.concat(aAddDesc, " ");
+		ActionDamage.applyDmgTypeEffectsToModRoll(rRoll, rSource, rTarget);
 	end
 
-	-- Add damage type info to roll description
-	encodeDamageTypes(rRoll);
+	ActionDamage.applyModifierKeysToModRoll(rRoll, rSource, rTarget);
+
+	ActionDamage.finalizeModRoll(rRoll);
 end
 
 function onDamageRoll(rSource, rRoll)
@@ -796,6 +529,294 @@ function onStabilization(rSource, rTarget, rRoll)
 	else
 		applyFailedStabilization(rSource);
 	end
+end
+
+--
+-- MOD ROLL HELPERS
+--
+
+function setupModRoll(rRoll, rSource, rTarget)
+	ActionDamage.decodeDamageTypes(rRoll);
+	CombatManager2.addRightClickDiceToClauses(rRoll);
+
+	rRoll.tNotifications = {};
+	
+	rRoll.bCritical = rRoll.bCritical or ModifierStack.getModifierKey("DMG_CRIT") or Input.isShiftPressed();
+	if ActionAttack.isCrit(rSource, rTarget) then
+		rRoll.bCritical = true;
+	end
+	rRoll.tAttackFilter = {};
+	if rRoll.range == "R" then
+		table.insert(rRoll.tAttackFilter, "ranged");
+	elseif rRoll.range == "M" then
+		table.insert(rRoll.tAttackFilter, "melee");
+	end
+
+	rRoll.bEffects = false;
+	rRoll.tEffectDice = {};
+	rRoll.nEffectMod = 0;
+end
+
+function applyAbilityEffectsToModRoll(rRoll, rSource, rTarget)
+	for _,vClause in ipairs(rRoll.clauses) do
+		-- Get original stat modifier
+		local nStatMod = ActorManager35E.getAbilityBonus(rSource, vClause.stat);
+		
+		-- Get any stat effects bonus
+		local nAbilityEffectMod, nAbilityEffects = ActorManager35E.getAbilityEffectsBonus(rSource, vClause.stat);
+		if nAbilityEffects > 0 then
+			rRoll.bEffects = true;
+			
+			-- Calc total stat mod
+			local nTotalStatMod = nStatMod + nAbilityEffectMod;
+			
+			-- Handle maximum stat mod setting
+			-- WORKAROUND: If max limited, then assume no penalty allowed (i.e. bows)
+			local nStatModMax = vClause.statmax or 0;
+			if nStatModMax > 0 then
+				nStatMod = math.max(math.min(nStatMod, nStatModMax), 0);
+				nTotalStatMod = math.max(math.min(nTotalStatMod, nStatModMax), 0);
+			end
+
+			-- Handle multipliers correctly
+			-- NOTE: Negative values are not multiplied, but positive values are.
+			local nMult = vClause.statmult or 1;
+			local nMultOrigStatMod, nMultNewStatMod;
+			if nStatMod <= 0 then
+				nMultOrigStatMod = nStatMod;
+			else
+				nMultOrigStatMod = math.floor(nStatMod * nMult);
+			end
+			if nTotalStatMod <= 0 then
+				nMultNewStatMod = nTotalStatMod;
+			else
+				nMultNewStatMod = math.floor(nTotalStatMod * nMult);
+			end
+			
+			-- Calculate bonus difference
+			local nMultDiffStatMod = nMultNewStatMod - nMultOrigStatMod;
+			
+			-- Apply bonus difference
+			rRoll.nEffectMod = rRoll.nEffectMod + nMultDiffStatMod;
+			vClause.modifier = vClause.modifier + nMultDiffStatMod;
+			rRoll.nMod = rRoll.nMod + nMultDiffStatMod;
+		end
+	end
+end
+
+function applyCriticalToModRoll(rRoll, rSource, rTarget)
+	table.insert(rRoll.tNotifications, "[CRITICAL]");
+
+	local nDieIndex = 1;
+	local aNewClauses = {};
+	for _,vClause in ipairs(rRoll.clauses) do
+		nDieIndex = nDieIndex + #(vClause.dice);
+		
+		table.insert(aNewClauses, vClause);
+		
+		local nMult = vClause.mult or 2;
+		if nMult > 1 then
+			local rNewClause = UtilityManager.copyDeep(vClause);
+			rNewClause.dice = {};
+			rNewClause.modifier = 0;
+			if rNewClause.dmgtype == "" then
+				rNewClause.dmgtype = "critical";
+			else
+				rNewClause.dmgtype = rNewClause.dmgtype .. ",critical";
+			end
+			
+			local nDice = #(vClause.dice);
+			local nMod = vClause.modifier or 0;
+			
+			for i = 2, nMult do
+				for j = 1, nDice do
+					if vClause.dice[j]:sub(1,1) == "-" then
+						table.insert(rRoll.aDice, nDieIndex, "-g" .. vClause.dice[j]:sub(3));
+					else
+						table.insert(rRoll.aDice, nDieIndex, "g" .. vClause.dice[j]:sub(2));
+					end
+					nDieIndex = nDieIndex + 1;
+					table.insert(rNewClause.dice, vClause.dice[j]);
+				end
+				rRoll.nMod = rRoll.nMod + nMod;
+				rNewClause.modifier = rNewClause.modifier + nMod;
+			end
+			
+			table.insert(aNewClauses, rNewClause);
+		end
+	end
+	rRoll.clauses = aNewClauses;
+end
+
+function applyDmgEffectsToModRoll(rRoll, rSource, rTarget)
+	local tEffects, nEffectCount;
+	if rRoll.sType == "spdamage" then
+		tEffects, nEffectCount = EffectManager35E.getEffectsBonusByType(rSource, "DMGS", true, rRoll.tAttackFilter, rTarget, false, rRoll.tags);
+	else
+		tEffects, nEffectCount = EffectManager35E.getEffectsBonusByType(rSource, "DMG", true, rRoll.tAttackFilter, rTarget, false, rRoll.tags);
+	end
+	if nEffectCount > 0 then
+		-- Use the first damage clause to determine damage type and crit multiplier for effect damage
+		local nEffectCritMult = 2;
+		local sEffectBaseType = "";
+		if #(rRoll.clauses) > 0 then
+			nEffectCritMult = rRoll.clauses[1].mult or 2;
+			sEffectBaseType = rRoll.clauses[1].dmgtype or "";
+		end
+
+		-- For each effect, add a damage clause
+		for _,v in pairs(tEffects) do
+			-- Process effect damage types
+			local bEffectPrecision = false;
+			local bEffectCritical = false;
+			local tEffectDmgType = {};
+			local tEffectSpecialDmgType = {};
+			for _,sWord in ipairs(v.remainder) do
+				if StringManager.contains(DataCommon.specialdmgtypes, sWord) then
+					table.insert(tEffectSpecialDmgType, sWord);
+					if sWord == "critical" then
+						bEffectCritical = true;
+					elseif sWord == "precision" then
+						bEffectPrecision = true;
+					end
+				elseif StringManager.contains(DataCommon.dmgtypes, sWord) then
+					table.insert(tEffectDmgType, sWord);
+				end
+			end
+			
+			if not bEffectCritical or rRoll.bCritical then
+				rRoll.bEffects = true;
+				
+				local rClause = {};
+				
+				-- Add effect dice
+				rClause.dice = {};
+				for _,vDie in ipairs(v.dice) do
+					table.insert(rRoll.tEffectDice, vDie);
+					table.insert(rClause.dice, vDie);
+					if vDie:sub(1,1) == "-" then
+						table.insert(rRoll.aDice, "-p" .. vDie:sub(3));
+					else
+						table.insert(rRoll.aDice, "p" .. vDie:sub(2));
+					end
+				end
+
+				if #tEffectDmgType == 0 then
+					table.insert(tEffectDmgType, sEffectBaseType);
+				end
+				for _,vSpecialDmgType in ipairs(tEffectSpecialDmgType) do
+					table.insert(tEffectDmgType, vSpecialDmgType);
+				end
+				rClause.dmgtype = table.concat(tEffectDmgType, ",");
+
+				local nCurrentMod = v.mod;
+				rRoll.nEffectMod = rRoll.nEffectMod + nCurrentMod;
+				rClause.modifier = nCurrentMod;
+				rRoll.nMod = rRoll.nMod + nCurrentMod;
+
+				table.insert(rRoll.clauses, rClause);
+				
+				-- Add critical effect modifier
+				if rRoll.bCritical and not bEffectPrecision and not bEffectCritical and nEffectCritMult > 1 then
+					local rClauseCritical = {};
+					local nCurrentMod = (v.mod * (nEffectCritMult - 1));
+					rClauseCritical.modifier = nCurrentMod;
+					if rClause.dmgtype == "" then
+						rClauseCritical.dmgtype = "critical";
+					else
+						rClauseCritical.dmgtype = rClause.dmgtype .. ",critical";
+					end
+					table.insert(rRoll.clauses, rClauseCritical);
+
+					rRoll.nEffectMod = rRoll.nEffectMod + nCurrentMod;
+					rRoll.nMod = rRoll.nMod + nCurrentMod;
+				end
+			end
+		end
+	end
+end
+
+function applyConditionsToModRoll(rRoll, rSource, rTarget)
+	if rRoll.sType ~= "spdamage" then
+		if EffectManager35E.hasEffectCondition(rSource, "Sickened", rRoll.tags) then
+			rRoll.nMod = rRoll.nMod - 2;
+			rRoll.nEffectMod = rRoll.nEffectMod - 2;
+			rRoll.bEffects = true;
+		end
+		if EffectManager35E.hasEffect(rSource, "Incorporeal", nil, false, false, rRoll.tags) and (rRoll.range == "M") 
+				and not rRoll.sDesc:lower():match("incorporeal touch") then
+			rRoll.bEffects = true;
+			table.insert(rRoll.tNotifications, "[INCORPOREAL]");
+		end
+	end
+end
+
+function applyEffectModNotificationToModRoll(rRoll)
+	if rRoll.bEffects then
+		local sEffects;
+		local sMod = StringManager.convertDiceToString(rRoll.tEffectDice, rRoll.nEffectMod, true);
+		if sMod ~= "" then
+			sEffects = "[" .. Interface.getString("effects_tag") .. " " .. sMod .. "]";
+		else
+			sEffects = "[" .. Interface.getString("effects_tag") .. "]";
+		end
+		table.insert(rRoll.tNotifications, sEffects);
+	end
+end
+
+function applyDmgTypeEffectsToModRoll(rRoll, rSource, rTarget)
+	local tAddDmgTypes = {};
+	local tDmgTypeEffects;
+	if rRoll.sType == "spdamage" then
+		tDmgTypeEffects = EffectManager35E.getEffectsByType(rSource, "DMGSTYPE", nil, rTarget, false, rRoll.tags);
+	else
+		tDmgTypeEffects = EffectManager35E.getEffectsByType(rSource, "DMGTYPE", nil, rTarget, false, rRoll.tags);
+	end
+	for _,rEffectComp in ipairs(tDmgTypeEffects) do
+		for _,v2 in ipairs(rEffectComp.remainder) do
+			if StringManager.contains(DataCommon.dmgtypes, v2) then
+				table.insert(tAddDmgTypes, v2);
+			end
+		end
+	end
+	if #tAddDmgTypes > 0 then
+		for _,vClause in ipairs(rRoll.clauses) do
+			local tSplitTypes = StringManager.split(vClause.dmgtype, ",", true);
+			for _,v2 in ipairs(tAddDmgTypes) do
+				if not StringManager.contains(tSplitTypes, v2) then
+					if vClause.dmgtype ~= "" then
+						vClause.dmgtype = vClause.dmgtype .. "," .. v2;
+					else
+						vClause.dmgtype = v2;
+					end
+				end
+			end
+		end
+
+		local sNotification = "[" .. Interface.getString("effects_tag") .. " " .. table.concat(tAddDmgTypes, ",") .. "]";
+		table.insert(rRoll.tNotifications, sNotification);
+	end
+end
+
+function applyModifierKeysToModRoll(rRoll, rSource, rTarget)
+	if ModifierStack.getModifierKey("DMG_HALF") then
+		table.insert(rRoll.tNotifications, "[HALF]");
+	end
+end
+
+function finalizeModRoll(rRoll)
+	if #(rRoll.tNotifications) > 0 then
+		rRoll.sDesc = rRoll.sDesc .. " " .. table.concat(rRoll.tNotifications, " ");
+	end
+
+	rRoll.tNotifications = nil;
+	rRoll.tAttackFilter = nil;
+
+	rRoll.bEffects = nil;
+	rRoll.tEffectDice = nil;
+	rRoll.nEffectMod = nil;
+
+	ActionDamage.encodeDamageTypes(rRoll);
 end
 
 --


### PR DESCRIPTION
While working on PR #4 I was trying to come up with a way to use the original functions in `modDamage` that were not actually affected by any changes needed by this extension. While that PR is quick and dirty to just get `modDamage` in line with the base rulesets this is much more expansive.

I noticed there were many more functions in the modified `manager_action_damage.lua`  that were unchanged from the original. I figured it would make it easier to maintain long term if `ActionDamage` only had the functions replaced that needed to be. So this PR does just that, it removes any function identical to the 3.5 `manager_action_damage.lua` definition of that function. I did have to make a few changes to some modified functions to call into the existing `ActionDamage` for unchanged functions, but overall have left any modified functions alone.