### PR TITLE
Effects O modifier like OCL

### DIFF
--- a/scripts/manager_effect_35E.lua
+++ b/scripts/manager_effect_35E.lua
@@ -390,8 +390,12 @@ function evalAbilityHelper(rActor, sEffectAbility, nodeSpellClass)
 		elseif ((sNumber or 0) ~= 0) and (sModifier == "d") then
 			nAbility = nAbility / (tonumber(sNumber) or 1);
 		end
-		if sSign:find("^", 0, true) then  -- Round the value
-			nAbility = math.ceil(nAbility);
+		if (nAbility ~= 0) and sSign:find("^", 0, true) then  -- Round the value
+			if nAbility > 0 then
+				nAbility = math.ceil(nAbility);
+			else
+				nAbility = math.floor(nAbility);
+			end
 		end
 		-- KEL This has to be before the sign change otherwise nMax always wins
 		if nMax then

--- a/scripts/manager_effect_35E.lua
+++ b/scripts/manager_effect_35E.lua
@@ -177,7 +177,7 @@ function parseEffectComp(s)
 		end
 		
 		if nRemainderIndex <= #aWords then
-			while nRemainderIndex <= #aWords and aWords[nRemainderIndex]:match("^%[%d?%a+%]$") do
+			while nRemainderIndex <= #aWords and aWords[nRemainderIndex]:match("^%[%-?%d?%a+%]$") do
 				table.insert(aRemainder, aWords[nRemainderIndex]);
 				nRemainderIndex = nRemainderIndex + 1;
 			end
@@ -320,7 +320,7 @@ end
 
 function evalAbilityHelper(rActor, sEffectAbility, nodeSpellClass)
 	-- KEL We add DCrumbs max stuff but we do it differently (espcially min is not needed)
-	local sSign, sModifier, sNumber, sShortAbility, nMax = sEffectAbility:match("^%[([%+%-]?)([HTQOd]?)([%d]?)([A-Z][A-Z][A-Z]?)(%d*)%]$");
+	local sSign, sModifier, sNumber, sShortAbility, nMax = sEffectAbility:match("^%[([%+%-%^]*)([HTQd]?)([%d]?)([A-Z][A-Z][A-Z]?)(%d*)%]$");
 	-- KEL adding rollable stats (for damage especially)
 	-- local sSign, sDieSides = sEffectAbility:match("^%[([%-%+]?)[dD]([%dF]+)%]$");
 	local sDie, sDesc = sEffectAbility:match("^%[%s*(%S+)%s*(.*)%]$");
@@ -380,8 +380,6 @@ function evalAbilityHelper(rActor, sEffectAbility, nodeSpellClass)
 	if nAbility and not IsDie then
 		if sModifier == "H" then
 			nAbility = nAbility / 2;
-		elseif sModifier == "O" then
-			nAbility = math.ceil(nAbility / 2);
 		elseif sModifier == "T" then
 			nAbility = nAbility / 3;
 		elseif sModifier == "Q" then
@@ -392,11 +390,14 @@ function evalAbilityHelper(rActor, sEffectAbility, nodeSpellClass)
 		elseif ((sNumber or 0) ~= 0) and (sModifier == "d") then
 			nAbility = nAbility / (tonumber(sNumber) or 1);
 		end
+		if sSign:find("^", 0, true) then  -- Round the value
+			nAbility = math.ceil(nAbility);
+		end
 		-- KEL This has to be before the sign change otherwise nMax always wins
 		if nMax then
 			nAbility = math.min(nAbility, (tonumber(nMax) or nAbility));
 		end
-		if sSign == "-" then
+		if sSign:find("-", 0, true) then
 			nAbility = 0 - nAbility;
 		end
 		-- KEL we round here for avoiding rounding errors
@@ -426,7 +427,7 @@ function evalEffect(rActor, s, nodeSpellClass)
 			-- KEL adding die possibility
 			local sDie, sDesc = rEffectComp.remainder[i]:match("^%[%s*(%S+)%s*(.*)%]$");
 			-- KEL TQD stuff
-			if rEffectComp.remainder[i]:match("^%[([%+%-]?)([HTQd]?)([%d]?)([A-Z][A-Z][A-Z]?)(%d*)%]$") or StringManager.isDiceString(sDie) then
+			if rEffectComp.remainder[i]:match("^%[([%+%-%^]*)([HTQd]?)([%d]?)([A-Z][A-Z][A-Z]?)(%d*)%]") or StringManager.isDiceString(sDie) then
 				local nAbility = evalAbilityHelper(rActor, rEffectComp.remainder[i], nodeSpellClass);
 				if nAbility then
 					rEffectComp.mod = rEffectComp.mod + nAbility;
@@ -437,7 +438,7 @@ function evalEffect(rActor, s, nodeSpellClass)
 		table.insert(aNewEffectComps, rebuildParsedEffectComp(rEffectComp));
 	end
 	local sOutput = EffectManager.rebuildParsedEffect(aNewEffectComps);
-	
+
 	return sOutput;
 end
 -- KEL add tags
@@ -482,7 +483,7 @@ function getEffectsByType(rActor, sEffectType, aFilter, rFilterActor, bTargetedO
 			if not bTargeted or EffectManager.isEffectTarget(v, rFilterActor) then
 				local sLabel = DB.getValue(v, "label", "");
 				local aEffectComps = EffectManager.parseEffect(sLabel);
-
+				
 				-- Look for type/subtype match
 				local nMatch = 0;
 				for kEffectComp, sEffectComp in ipairs(aEffectComps) do
@@ -533,7 +534,7 @@ function getEffectsByType(rActor, sEffectType, aFilter, rFilterActor, bTargetedO
 						-- Strip energy/bonus types for subtype comparison
 						local aEffectRangeFilter = {};
 						local aEffectOtherFilter = {};
-
+						
 						local aComponents = {};
 						for _,vPhrase in ipairs(rEffectComp.remainder) do
 							local nTempIndexOR = 0;
@@ -547,7 +548,7 @@ function getEffectsByType(rActor, sEffectType, aFilter, rFilterActor, bTargetedO
 									table.insert(aPhraseOR, vPhrase:sub(nTempIndexOR));
 								end
 							until nStartOR == nil;
-
+							
 							for _,vPhraseOR in ipairs(aPhraseOR) do
 								local nTempIndexAND = 0;
 								repeat
@@ -577,7 +578,7 @@ function getEffectsByType(rActor, sEffectType, aFilter, rFilterActor, bTargetedO
 							
 							j = j + 1;
 						end
-
+					
 						-- Check for match
 						local comp_match = false;
 						if rEffectComp.type == sEffectType then
@@ -588,7 +589,7 @@ function getEffectsByType(rActor, sEffectType, aFilter, rFilterActor, bTargetedO
 							else
 								comp_match = true;
 							end
-
+						
 							-- Check filters
 							if #aEffectRangeFilter > 0 then
 								local bRangeMatch = false;
@@ -656,7 +657,7 @@ function getEffectsByType(rActor, sEffectType, aFilter, rFilterActor, bTargetedO
 			end -- END TARGET CHECK
 		end  -- END ACTIVE CHECK
 	end  -- END EFFECT LOOP
-
+	
 	return results;
 end
 -- KEL add tags
@@ -843,7 +844,7 @@ function hasEffect(rActor, sEffect, rTarget, bTargetedOnly, bIgnoreEffectTargets
 		return false, 0;
 	end
 	local sLowerEffect = sEffect:lower();
-
+	
 	-- Iterate through each effect
 	local aMatch = {};
 	for _,v in pairs(DB.getChildren(ActorManager.getCTNode(rActor), "effects")) do
@@ -921,7 +922,7 @@ function hasEffect(rActor, sEffect, rTarget, bTargetedOnly, bIgnoreEffectTargets
 				end
 				
 			end
-
+			
 			-- If matched, then remove one-off effects
 			if nMatch > 0 then
 				if nActive == 2 then
@@ -940,7 +941,7 @@ function hasEffect(rActor, sEffect, rTarget, bTargetedOnly, bIgnoreEffectTargets
 			end
 		end
 	end
-
+	
 	if #aMatch > 0 then
 		return true, #aMatch;
 	end
@@ -1104,7 +1105,6 @@ end
 function checkTagConditional(aConditions, rEffectSpell)
 	if rEffectSpell then
 		local tagshelp = StringManager.parseWords(rEffectSpell);
-		
 		if not tagshelp[1] then
 			return false;
 		end

--- a/scripts/manager_effect_35E.lua
+++ b/scripts/manager_effect_35E.lua
@@ -330,7 +330,7 @@ end
 
 function evalAbilityHelper(rActor, sEffectAbility, nodeSpellClass)
 	-- KEL We add DCrumbs max stuff but we do it differently (espcially min is not needed)
-	local sSign, sModifier, sNumber, sShortAbility, nMax = sEffectAbility:match("^%[([%+%-]?)([HTQd]?)([%d]?)([A-Z][A-Z][A-Z]?)(%d*)%]$");
+	local sSign, sModifier, sNumber, sShortAbility, nMax = sEffectAbility:match("^%[([%+%-]?)([HTQOd]?)([%d]?)([A-Z][A-Z][A-Z]?)(%d*)%]$");
 	-- KEL adding rollable stats (for damage especially)
 	-- local sSign, sDieSides = sEffectAbility:match("^%[([%-%+]?)[dD]([%dF]+)%]$");
 	local sDie, sDesc = sEffectAbility:match("^%[%s*(%S+)%s*(.*)%]$");
@@ -390,6 +390,8 @@ function evalAbilityHelper(rActor, sEffectAbility, nodeSpellClass)
 	if nAbility and not IsDie then
 		if sModifier == "H" then
 			nAbility = nAbility / 2;
+		elseif sModifier == "O" then
+			nAbility = math.ceil(nAbility / 2);
 		elseif sModifier == "T" then
 			nAbility = nAbility / 3;
 		elseif sModifier == "Q" then

--- a/scripts/manager_effect_35E.lua
+++ b/scripts/manager_effect_35E.lua
@@ -21,6 +21,16 @@ end
 -- EFFECT MANAGER OVERRIDES
 --
 
+-- KEL compatibility with rmilmine
+-- function isAEOk(rActor, v)
+	-- if StringManager.contains(Extension.getExtensions(), "Advanced Effects for 3.5E and Pathfinder") then
+		-- return EffectManagerAE.isValidCheckEffect(rActor,v);
+	-- else
+		-- return true;
+	-- end
+-- end
+-- END
+
 function onEffectAddStart(rEffect)
 	rEffect.nDuration = rEffect.nDuration or 1;
 	if rEffect.sUnits == "minute" then
@@ -390,8 +400,12 @@ function evalAbilityHelper(rActor, sEffectAbility, nodeSpellClass)
 		elseif ((sNumber or 0) ~= 0) and (sModifier == "d") then
 			nAbility = nAbility / (tonumber(sNumber) or 1);
 		end
-		if sSign:find("^", 0, true) then  -- Round the value
-			nAbility = math.ceil(nAbility);
+		if ((nAbility ~= 0) and (sSign:find("^", 0, true))) then  -- Round the value
+			if nAbility > 0 then
+				nAbility = math.ceil(nAbility);
+			else
+				nAbility = math.floor(nAbility);
+			end
 		end
 		-- KEL This has to be before the sign change otherwise nMax always wins
 		if nMax then
@@ -438,7 +452,7 @@ function evalEffect(rActor, s, nodeSpellClass)
 		table.insert(aNewEffectComps, rebuildParsedEffectComp(rEffectComp));
 	end
 	local sOutput = EffectManager.rebuildParsedEffect(aNewEffectComps);
-
+	
 	return sOutput;
 end
 -- KEL add tags
@@ -447,7 +461,7 @@ function getEffectsByType(rActor, sEffectType, aFilter, rFilterActor, bTargetedO
 		return {};
 	end
 	local results = {};
-
+	
 	-- Set up filters
 	local aRangeFilter = {};
 	local aOtherFilter = {};
@@ -462,22 +476,15 @@ function getEffectsByType(rActor, sEffectType, aFilter, rFilterActor, bTargetedO
 			end
 		end
 	end
-
+	
 	-- Determine effect type targeting
 	local bTargetSupport = StringManager.isWord(sEffectType, DataCommon.targetableeffectcomps);
-
+	
 	-- Iterate through effects
 	for _,v in pairs(DB.getChildren(ActorManager.getCTNode(rActor), "effects")) do
 		-- Check active
 		local nActive = DB.getValue(v, "isactive", 0);
-
-		-- COMPATIBILITY FOR ADVANCED EFFECTS
-		-- to add support for AE in other extensions, make this change
-		-- Check effect is from used weapon.
-		-- original line: if nActive ~= 0 then
-		if ((not AdvancedEffects and nActive ~= 0) or (AdvancedEffects and AdvancedEffects.isValidCheckEffect(rActor,v))) then
-		-- END COMPATIBILITY FOR ADVANCED EFFECTS
-
+		if (nActive ~= 0) then
 			-- Check targeting
 			local bTargeted = EffectManager.isTargetedEffect(v);
 			if not bTargeted or EffectManager.isEffectTarget(v, rFilterActor) then
@@ -834,7 +841,7 @@ function getEffectsBonus(rActor, aEffectType, bModOnly, aFilter, rFilterActor, b
 	end
 	return aTotalDice, nTotalMod, nEffectCount;
 end
--- KEL Adding tags and IFTAG to 
+-- KEL Adding tags and IFTAG to hasEffect
 function hasEffectCondition(rActor, sEffect, rEffectSpell)
 	return hasEffect(rActor, sEffect, nil, false, true, rEffectSpell);
 end
@@ -849,13 +856,7 @@ function hasEffect(rActor, sEffect, rTarget, bTargetedOnly, bIgnoreEffectTargets
 	local aMatch = {};
 	for _,v in pairs(DB.getChildren(ActorManager.getCTNode(rActor), "effects")) do
 		local nActive = DB.getValue(v, "isactive", 0);
-
-		-- COMPATIBILITY FOR ADVANCED EFFECTS
-		-- to add support for AE in other extensions, make this change
-		-- original line: if nActive ~= 0 then
-		if ((not AdvancedEffects and nActive ~= 0) or (AdvancedEffects and AdvancedEffects.isValidCheckEffect(rActor,v))) then
-		-- END COMPATIBILITY FOR ADVANCED EFFECTS
-
+		if (nActive ~= 0) then
 			-- Parse each effect label
 			local sLabel = DB.getValue(v, "label", "");
 			local bTargeted = EffectManager.isTargetedEffect(v);


### PR DESCRIPTION
Add O modifer to effect parsing (alongside HTQ). The O modifier acts in the same way as the H modifier but will round the value (math.ceil) rather than truncate it (math.floor). This allows an effect like Holy Vindicator - Vindicator's Shield to be coded where the bonus is equal to the number of Channel Energy dice of the character and those dice go up on odd levels.
e.g. for a character that is Cleric 9 / Holy Vindicator 4 their effective level for channel energy is 13 which gives 7d6. [HCL] would give an incorrect modifier of 6, this [OCL] change would give a correct modifier of 7.  Other variant of HCL effects like '0.5 HCL' or '1 HCL' also do not consistently give the correct result, some are correct for odd CLs and wrong for even CLs and vice versa.