### PR TITLE
add expanded ac bonuses

### DIFF
--- a/scripts/manager_actor_35E.lua
+++ b/scripts/manager_actor_35E.lua
@@ -772,7 +772,8 @@ function getDefenseValue(rAttacker, rDefender, rRoll)
 			table.insert(aIgnoreEffects, "naturalsize");
 			table.insert(aIgnoreEffects, "armorenhancement");
 			table.insert(aIgnoreEffects, "shieldenhancement");
-			table.insert(aIgnoreEffects, "naturalenhancement");		end
+			table.insert(aIgnoreEffects, "naturalenhancement");
+		end
 		if bFlatFooted or bCombatAdvantage then
 			table.insert(aIgnoreEffects, "dodge");
 		end

--- a/scripts/manager_actor_35E.lua
+++ b/scripts/manager_actor_35E.lua
@@ -769,7 +769,10 @@ function getDefenseValue(rAttacker, rDefender, rRoll)
 			table.insert(aIgnoreEffects, "armor");
 			table.insert(aIgnoreEffects, "shield");
 			table.insert(aIgnoreEffects, "natural");
-		end
+			table.insert(aIgnoreEffects, "naturalsize");
+			table.insert(aIgnoreEffects, "armorenhancement");
+			table.insert(aIgnoreEffects, "shieldenhancement");
+			table.insert(aIgnoreEffects, "naturalenhancement");		end
 		if bFlatFooted or bCombatAdvantage then
 			table.insert(aIgnoreEffects, "dodge");
 		end


### PR DESCRIPTION
[Natural and armor AC bonuses have some sub-bonuses that stack with each other.
Some abilities in Pathfinder say they provide "a size bonus to natural armor" and complex things like this.](https://www.fantasygrounds.com/forums/showthread.php?58962-PFRPG-Spellbook&p=597195&viewfull=1#post597195)
These new bonus types do not increase touch AC but do stack with armor and natural bonuses.