### PR TITLE
Patching compatibility for Advanced Charsheet & Live Hitpoints

### DIFF
--- a/campaign/record_char_main.xml
+++ b/campaign/record_char_main.xml
@@ -8,10 +8,7 @@
 <root>
 	<windowclass name="charsheet_main" merge="join">
 		<sheetdata>
-			<number_dropadd name="nonlethal" source="hp.nonlethal" merge="replace">
-				<anchored to="wounds" position="right" offset="20,0" width="40" />
-				<hideonvalue>0</hideonvalue>
-				<description textres="char_tooltip_nonlethal" />
+			<number_dropadd name="nonlethal" source="hp.nonlethal">
 				<script>
 					function onValueChanged()
 						window.onHealthChanged();

--- a/campaign/record_spell_roll.xml
+++ b/campaign/record_spell_roll.xml
@@ -6,7 +6,6 @@
 -->
 
 <root>
-	<windowclass name="power_cast_editor_main" merge="delete"> </windowclass>
 	<windowclass name="power_cast_editor_main" >
 		<script file="campaign/scripts/replace_dc.lua" />
 		<sheetdata>


### PR DESCRIPTION
- Fixes a compatibility issue when using Extended Automation, Advanced Charsheet & Live Hitpoints. Extended Automation was unneccessarily overriding the anchoring of the nonlethal numberfield
- Removes an unneccessary windowclass deletion