### PR TITLE
Delete unnecessary onInit in char.lua

### DIFF
--- a/campaign/scripts/char.lua
+++ b/campaign/scripts/char.lua
@@ -3,14 +3,6 @@
 -- attribution and copyright information.
 --
 
-function onInit()
-	if Session.IsHost then
-		registerMenuItem(Interface.getString("menu_rest"), "lockvisibilityon", 7);
-		registerMenuItem(Interface.getString("menu_restshort"), "pointer_cone", 7, 8);
-		registerMenuItem(Interface.getString("menu_restovernight"), "pointer_circle", 7, 6);
-	end
-end
-
 function onMenuSelection(selection, subselection)
 	if selection == 7 then
 		if subselection == 8 then


### PR DESCRIPTION
- Deletes the unnecessary onInit in char.lua. This is already done in upstream rulesets and works just fine like this
- This is also now compatible with a trio of Advanced Charsheet and Extra-Actions