### PR TITLE
Update manager_action_skill.lua to improve compatibility with other skill mod affecting extensions

### DIFF
--- a/scripts/manager_action_skill.lua
+++ b/scripts/manager_action_skill.lua
@@ -1,4 +1,5 @@
 function onInit()
+    ActionSkill.modSkill = modSkill
     ActionsManager.registerModHandler("skill", modSkill);
 end
 


### PR DESCRIPTION
By overwriting the original ActionSkill.modSkill when other extensions want to add functionality to it they'll now find this extension's function instead. Previously extensions would find the original ActionSkill from the base ruleset and the functionality here would be lost.